### PR TITLE
docs: sync OSS checklist with v0.1.0 release completion

### DIFF
--- a/docs/open-source-release-checklist.md
+++ b/docs/open-source-release-checklist.md
@@ -101,21 +101,21 @@ Scope: repository-level launch readiness for Recurgent (Ruby runtime first, Lua 
 
 ## 10. Release Artifact and Versioning
 
-- [ ] Decide and tag first public version (for example `v0.1.0`).
+- [x] Decide and tag first public version (for example `v0.1.0`).
 - [x] Ensure `CHANGELOG.md` has release notes for initial public release.
 - [x] Ensure runtime gem metadata links are valid (`homepage`, `source_code_uri`, `changelog_uri`).
 - [x] Confirm release process doc aligns with actual tagging and publishing commands.
-- [ ] Prepare release notes with:
-  - [ ] what is stable
-  - [ ] what is experimental
-  - [ ] migration notes (if any)
+- [x] Prepare release notes with:
+  - [x] what is stable
+  - [x] what is experimental
+  - [x] migration notes (if any)
 
 ## 11. Launch Day Checklist
 
 - [ ] Run final clean-room setup using onboarding docs.
 - [x] Run full tests/lint one final time on clean tree.
 - [ ] Verify examples used in README run without manual patching.
-- [ ] Publish release/tag.
+- [x] Publish release/tag.
 - [ ] Announce with clear expectations and known limitations.
 - [ ] Monitor first 24h issues and discussions.
 
@@ -150,6 +150,7 @@ Completed locally on 2026-02-18:
   - GitHub Dependabot vulnerability alerts enabled for the repository.
   - Branch protection enforces required checks: `Ruby test and lint`, `Enforce PR template and issue-first policy`, `bundler-audit`, `gitleaks`.
   - Secret scanning and code scanning still require repository visibility/licensing changes (tracked in Section 9 and Section 7).
+  - `v0.1.0` tag and release published: `https://github.com/kulesh/recurgent/releases/tag/v0.1.0`.
 
 ## Suggested Operating Rule
 


### PR DESCRIPTION
## Linked Issue (Required)

Closes #9

## Problem and User Value (Required)

The OSS checklist still marked release/tag tasks as incomplete after `v0.1.0` was tagged and published, creating inaccurate launch readiness state.

## Solution Summary (Required)

Updated `docs/open-source-release-checklist.md` to:
- mark release/tag and release-notes tasks complete
- mark launch-day release/tag publication complete
- record release URL in verification notes

## Verification (Required)

```bash
gh release list --repo kulesh/recurgent --limit 10
git tag --list 'v*'
```

Verified `v0.1.0` exists as tag and GitHub release.

## Scope Declaration (Required)

Checklist status synchronization only; no runtime behavior changes.

## Contributor Acknowledgements (Required)

- [x] I linked an approved issue for this PR.
- [x] I ran relevant tests/lint and reported results above.
- [x] I reviewed every changed line and can explain it.
- [x] I read and agree to follow `CONTRIBUTING.md`.
- [x] I read and agree to follow `CODE_OF_CONDUCT.md`.
