### PR TITLE
docs: add progressive assistant tutorial and runtime config guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,7 +206,7 @@ runtimes/
 
 ## Retrieval Index
 
-Last Updated (UTC): 2026-02-20T03:57:23Z
+Last Updated (UTC): 2026-02-20T05:16:33Z
 
 - `README.md` - project introduction, quickstart, architecture snapshot, FAQ
 - `LICENSE` - MIT open source license
@@ -218,12 +218,15 @@ Last Updated (UTC): 2026-02-20T03:57:23Z
 - `docs/index.md` - top-level documentation map organized by product, architecture, ADRs, and plans
 - `docs/architecture.md` - canonical runtime architecture map for dispatch, retry lanes, persistence, boundary normalization, and observability
 - `docs/onboarding.md` - setup, developer workflow, quality gates
+- `docs/runtime-configuration.md` - runtime configuration reference for dependency policy, persistence roots, lifecycle toggles, and authority controls
 - `docs/specs/idea-brief.md` - concept vision, rationale, demos, future direction
 - `docs/specs/recursim-product-spec.md` - product specification for Recursim simulator focused on robustness and reliable emergence in self-contained systems
 - `docs/observability.md` - mechanistic interpretability model, shared log schema, and live watcher usage
 - `docs/ubiquitous-language.md` - canonical Tool Builder/Tool vocabulary and naming rules
 - `docs/tolerant-delegation-interfaces.md` - canonical tolerant delegation interface guidance and examples
 - `docs/delegate-vs-for.md` - concrete decision rules for delegate vs Agent.for usage
+- `docs/tutorials/README.md` - tutorial map for progressive, runnable documentation paths
+- `docs/tutorials/personal-assistant-progressive.md` - progressive personal-assistant tutorial from minimal loop to contracts, role profiles, observability, and authority-gated evolution
 - `docs/specs/delegation-contracts.md` - Phase 1 Tool Builder-authored Tool contract fields and behavior
 - `docs/adrs/TEMPLATE.md` - ADR authoring template that requires status quo baseline, expected improvements, validation signals, and rollback triggers
 - `docs/plans/README.md` - implementation plan map organized by runtime evolution, boundary hardening, and telemetry/context work

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,11 @@ This index is organized for fast retrieval:
 - `docs/tolerant-delegation-interfaces.md` - tolerant interface guidance
 - `docs/delegate-vs-for.md` - `delegate(...)` vs `Agent.for(...)` decision guide
 
+## Tutorials
+
+- `docs/tutorials/README.md` - tutorial map
+- `docs/tutorials/personal-assistant-progressive.md` - progressive walkthrough from minimal assistant to profile-aware, observable, governed runtime behavior
+
 ## Architecture Decisions
 
 - `docs/adrs/0001-core-dispatch-via-method-missing.md`
@@ -79,6 +84,7 @@ This index is organized for fast retrieval:
 - `docs/baselines/2026-02-20/adr-0024/phase-rollup.json` - ADR 0024 phase-by-phase validation rollup
 - `docs/reports/adr-0024-phase-validation-rollup.md` - ADR 0024 expected-vs-observed validation analysis
 - `docs/reports/adr-0024-scope-hardcut-validation-report.md` - validation report for scope-first role-profile hard cut and required calculator/assistant traces
+- `docs/runtime-configuration.md` - runtime configuration reference for dependency policy, lifecycle toggles, toolstore roots, and authority settings
 - `docs/roadmap.md` - near/mid/long-term roadmap
 - `docs/maintenance.md` - dependency/runtime maintenance policy
 - `docs/release-process.md` - release process and SemVer policy

--- a/docs/runtime-configuration.md
+++ b/docs/runtime-configuration.md
@@ -1,0 +1,130 @@
+# Runtime Configuration (Ruby)
+
+This page is the operational reference for `Agent.configure_runtime` and related environment variables.
+
+Primary implementation sources:
+- `runtimes/ruby/lib/recurgent/runtime_config.rb`
+- `runtimes/ruby/lib/recurgent.rb`
+
+## Why This Matters
+
+Runtime configuration controls:
+- dependency resolution policy,
+- persistence roots (toolstore + logs),
+- lifecycle capture/enforcement switches (promotion, role profiles),
+- authority enforcement for proposal apply/rollback flows.
+
+Set configuration **before** creating top-level agents.
+
+```ruby
+Agent.configure_runtime(
+  toolstore_root: "/tmp/recurgent-tools",
+  role_profile_shadow_mode_enabled: true,
+  role_profile_enforcement_enabled: false
+)
+```
+
+## Configure Runtime API
+
+`Agent.configure_runtime(gem_sources:, source_mode:, allowed_gems:, blocked_gems:, **options)`
+
+Dependency policy keys:
+- `gem_sources` (`Array<String>`)
+- `source_mode` (`"public_only"` or `"internal_only"`)
+- `allowed_gems` (`Array<String>|nil`)
+- `blocked_gems` (`Array<String>|nil`)
+
+Toolstore/telemetry/evolution keys (`options`):
+- `toolstore_root` (`String`)
+- `solver_shape_capture_enabled` (`Boolean`)
+- `self_model_capture_enabled` (`Boolean`)
+- `promotion_shadow_mode_enabled` (`Boolean`)
+- `promotion_enforcement_enabled` (`Boolean`)
+- `role_profile_shadow_mode_enabled` (`Boolean`)
+- `role_profile_enforcement_enabled` (`Boolean`)
+- `authority_enforcement_enabled` (`Boolean`)
+- `authority_maintainers` (`Array<String>` or comma-delimited `String`)
+
+Unknown `options` keys raise `ArgumentError`.
+
+## Defaults
+
+Defaults come from `Agent.runtime_config`:
+- `gem_sources`: `["https://rubygems.org"]`
+- `source_mode`: `"public_only"`
+- `toolstore_root`: `ENV["RECURGENT_TOOLSTORE_ROOT"]` or XDG default
+- `solver_shape_capture_enabled`: `true`
+- `self_model_capture_enabled`: `true`
+- `promotion_shadow_mode_enabled`: `true`
+- `promotion_enforcement_enabled`: `false`
+- `role_profile_shadow_mode_enabled`: `true`
+- `role_profile_enforcement_enabled`: `false`
+- `authority_enforcement_enabled`: `true`
+- `authority_maintainers`: from `RECURGENT_AUTHORITY_MAINTAINERS` or current `$USER`
+
+XDG defaults:
+- log path: `#{XDG_STATE_HOME:-~/.local/state}/recurgent/recurgent.jsonl`
+- toolstore root: `#{XDG_STATE_HOME:-~/.local/state}/recurgent/tools`
+
+## Environment Variables
+
+All booleans accept: `1|true|yes|on` and `0|false|no|off`.
+
+- `RECURGENT_TOOLSTORE_ROOT`
+- `RECURGENT_SOLVER_SHAPE_CAPTURE_ENABLED`
+- `RECURGENT_SELF_MODEL_CAPTURE_ENABLED`
+- `RECURGENT_PROMOTION_SHADOW_MODE_ENABLED`
+- `RECURGENT_PROMOTION_ENFORCEMENT_ENABLED`
+- `RECURGENT_ROLE_PROFILE_SHADOW_MODE_ENABLED`
+- `RECURGENT_ROLE_PROFILE_ENFORCEMENT_ENABLED`
+- `RECURGENT_AUTHORITY_ENFORCEMENT_ENABLED`
+- `RECURGENT_AUTHORITY_MAINTAINERS`
+- `XDG_STATE_HOME` (indirect: log path + default toolstore root)
+
+## Recommended Profiles
+
+### Local Development
+
+```ruby
+Agent.configure_runtime(
+  promotion_shadow_mode_enabled: true,
+  promotion_enforcement_enabled: false,
+  role_profile_shadow_mode_enabled: true,
+  role_profile_enforcement_enabled: false
+)
+```
+
+### Continuity Enforcement Trial
+
+```ruby
+Agent.configure_runtime(
+  role_profile_shadow_mode_enabled: true,
+  role_profile_enforcement_enabled: true
+)
+```
+
+### Governed Proposal Flows
+
+```ruby
+Agent.configure_runtime(
+  authority_enforcement_enabled: true,
+  authority_maintainers: %w[kulesh maintainer2]
+)
+```
+
+## Verification Checklist
+
+After changing runtime config:
+1. run `bundle exec rubocop` and `bundle exec rspec` in `runtimes/ruby`,
+2. run `ruby examples/calculator.rb`,
+3. run `ruby examples/assistant.rb`,
+4. inspect `recurgent.jsonl` per `docs/observability.md`.
+
+## Related Docs
+
+- `docs/architecture.md`
+- `docs/observability.md`
+- `docs/specs/delegation-contracts.md`
+- `docs/adrs/0023-solver-shape-and-reliability-gated-tool-evolution.md`
+- `docs/adrs/0024-contract-first-role-profiles-and-state-continuity-guard.md`
+- `docs/adrs/0025-awareness-substrate-and-authority-boundary.md`

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -1,0 +1,5 @@
+# Tutorials
+
+Progressive, engineer-focused walkthroughs that start with runnable minimal examples and evolve toward production-oriented patterns.
+
+- `docs/tutorials/personal-assistant-progressive.md` - end-to-end tutorial that evolves one personal-assistant example through delegation, contracts, role profiles, observability, governance, and log forensics (including a copy/paste quickstart).

--- a/docs/tutorials/personal-assistant-progressive.md
+++ b/docs/tutorials/personal-assistant-progressive.md
@@ -1,0 +1,398 @@
+# Tutorial: Personal Assistant (Progressive)
+
+Audience: software engineers who want a practical, stepwise path from first call to governed, observable, profile-aware agent behavior.
+
+This tutorial uses one evolving artifact: `runtimes/ruby/examples/assistant.rb`.
+
+## Reading Modes
+
+- Quick Path (15-25 min): run checkpoints only, observe behavior.
+- Deep Path (60-120 min): apply each code change, inspect traces, and follow topic links.
+
+## Prerequisites
+
+1. Follow setup in `docs/onboarding.md`.
+2. Work from `runtimes/ruby`.
+3. Use isolated state roots during exercises to keep traces reproducible:
+
+```bash
+XDG_STATE_HOME=$PWD/../../tmp/tutorial-assistant/phase-0 bundle exec ruby examples/assistant.rb
+```
+
+## Copy/Paste Quickstart (10-15 min)
+
+Run one complete loop (assistant + traces) before reading chapter details.
+
+```bash
+cd runtimes/ruby
+ROOT="$PWD/../../tmp/tutorial-assistant/quickstart"
+mkdir -p "$ROOT"
+
+cat > "$ROOT/assistant_input.txt" <<'EOF'
+What's the top news items in Google News, Yahoo! News, and NY Times
+What's are the action adventure movies playing in theaters
+What's a good recipe for Jaffna Kool
+quit
+EOF
+
+XDG_STATE_HOME="$ROOT/xdg" bundle exec ruby examples/assistant.rb < "$ROOT/assistant_input.txt" | tee "$ROOT/assistant.out"
+tail -n 8 "$ROOT/xdg/recurgent/recurgent.jsonl"
+rg '"depth":0' "$ROOT/xdg/recurgent/recurgent.jsonl" | rg '"outcome_status":"error"'
+```
+
+What to verify:
+1. all three prompts return usable responses,
+2. top-level failures (if any) are visible in JSONL,
+3. delegation/guardrail behavior is visible without changing code.
+
+## Baseline Mental Model
+
+- Top-level role is a Tool Builder (`Agent.for(...)`).
+- Calls return `Agent::Outcome`.
+- Delegations are tools created/reused through runtime policy.
+- Runtime state and telemetry are first-class (toolstore + JSONL logs).
+
+References:
+- `docs/architecture.md`
+- `docs/ubiquitous-language.md`
+- `docs/delegate-vs-for.md`
+
+## Recurgent Terms Used Here
+
+These terms are domain-specific and appear throughout the chapters.
+
+- `Tool Builder`: the top-level agent that owns user intent and synthesis.
+- `Tool`: a delegated agent that executes a narrower capability boundary.
+- `Delegate`: one Tool Builder action to materialize/invoke a Tool.
+- `Outcome`: normalized return envelope (`ok?`, `value`, typed error fields).
+- `Role Profile`: explicit role-level contract for sibling method coherence.
+- `State Continuity Guard`: guardrail that enforces profile continuity expectations.
+- `Shadow Mode`: evaluate and log policy/profile outcomes without blocking success.
+- `Enforcement Mode`: policy/profile failures can block and trigger retries/typed errors.
+- `Self Model`: captured awareness snapshot (`awareness_level`, authority, active versions).
+- `Authority Boundary`: observe/propose is open; enact is explicitly gated.
+
+Canonical reference:
+- `docs/ubiquitous-language.md`
+
+## Chapter Sequence
+
+### Chapter 0: Minimal Assistant
+
+Goal: run the assistant and understand the raw interaction loop.
+
+File:
+- `runtimes/ruby/examples/assistant.rb`
+
+Code snippet:
+```ruby
+require_relative "../lib/recurgent"
+
+assistant = Agent.for("personal assistant that remembers conversation history", model: Agent::DEFAULT_MODEL)
+
+loop do
+  print "> "
+  input = $stdin.gets&.chomp
+  break if input.nil? || %w[quit exit].include?(input.downcase)
+  next if input.strip.empty?
+
+  puts assistant.ask(input)
+end
+```
+
+Run:
+```bash
+cd runtimes/ruby
+XDG_STATE_HOME=$PWD/../../tmp/tutorial-assistant/phase-0 ruby examples/assistant.rb
+```
+
+Checkpoint:
+1. prompt/response loop works,
+2. `ask` returns structured outcomes (success or typed failure).
+
+Deep links:
+- `runtimes/ruby/README.md`
+- `docs/onboarding.md`
+
+### Chapter 1: Runtime Configuration
+
+Goal: configure behavior intentionally before creating agents.
+
+Add/modify:
+1. `Agent.configure_runtime(...)` block in `assistant.rb`.
+2. isolate state root for deterministic traces.
+
+Code snippet:
+```ruby
+Agent.configure_runtime(
+  role_profile_shadow_mode_enabled: true,
+  role_profile_enforcement_enabled: true,
+  promotion_shadow_mode_enabled: true,
+  promotion_enforcement_enabled: false
+)
+```
+
+Run:
+```bash
+cd runtimes/ruby
+XDG_STATE_HOME=$PWD/../../tmp/tutorial-assistant/phase-1 ruby examples/assistant.rb
+```
+
+Checkpoint:
+1. verify `recurgent.jsonl` is written under the phase-specific state root,
+2. verify configured toggles (for example role-profile shadow/enforcement) are reflected in logs.
+
+Deep links:
+- `docs/runtime-configuration.md`
+- `docs/observability.md`
+
+### Chapter 2: Delegation with Explicit Contracts
+
+Goal: make delegated behavior explicit and testable.
+
+Exercise:
+1. ask for multi-source news and observe delegation,
+2. ensure delegated tools carry `purpose`, `deliverable`, `acceptance`, `failure_policy` where appropriate.
+
+Code snippet (explicit delegation contract):
+```ruby
+news_tool = assistant.delegate(
+  "news_aggregator",
+  purpose: "fetch top headlines from multiple sources",
+  deliverable: { type: "object", required: %w[headlines provenance] },
+  acceptance: [{ assert: "headlines contains concrete items" }],
+  failure_policy: { on_error: "return_error" }
+)
+
+news = news_tool.get_headlines(sources: %w[google yahoo nytimes])
+puts news.ok? ? news.value : "#{news.error_type}: #{news.error_message}"
+```
+
+Checkpoint:
+1. delegated calls appear in logs (`depth > 0`),
+2. top-level assistant remains concise while child tools execute concrete capability work.
+
+Deep links:
+- `docs/specs/delegation-contracts.md`
+- `docs/tolerant-delegation-interfaces.md`
+- `docs/delegate-vs-for.md`
+
+### Chapter 3: External Data + Provenance
+
+Goal: enforce source-aware success semantics on external data.
+
+Exercise:
+1. run a news query,
+2. inspect returned payload for provenance envelope,
+3. inspect logs for guardrail behavior if provenance is missing.
+
+Code snippet (expected success shape):
+```ruby
+{
+  headlines: [...],
+  provenance: {
+    sources: [
+      {
+        uri: "https://news.google.com/rss?hl=en-US&gl=US&ceid=US:en",
+        fetched_at: "2026-02-20T03:54:48Z",
+        retrieval_tool: "news_aggregator",
+        retrieval_mode: "live"
+      }
+    ]
+  }
+}
+```
+
+Checkpoint:
+1. successful external-data outcomes include provenance sources,
+2. provenance violations surface as typed failures/guardrail retries.
+
+Deep links:
+- `docs/adrs/0021-external-data-provenance-invariant.md`
+- `docs/observability.md`
+
+### Chapter 4: Add Role Profile Constraints
+
+Goal: move from implicit conventions to explicit continuity contracts.
+
+Use profile style already present in `assistant.rb`:
+1. `kind: :shared_state_slot`
+2. `scope: :all_methods`
+3. `mode: :prescriptive`
+4. `canonical_key: :conversation_history`
+
+Code snippet:
+```ruby
+ASSISTANT_ROLE_PROFILE = {
+  role: "personal assistant that remembers conversation history",
+  version: 1,
+  constraints: {
+    conversation_history_slot: {
+      kind: :shared_state_slot,
+      scope: :all_methods,
+      mode: :prescriptive,
+      canonical_key: :conversation_history
+    }
+  }
+}.freeze
+
+assistant = Agent.for(
+  "personal assistant that remembers conversation history",
+  model: Agent::DEFAULT_MODEL,
+  role_profile: ASSISTANT_ROLE_PROFILE
+)
+```
+
+Checkpoint:
+1. profile version appears in call telemetry,
+2. continuity drift triggers typed violations when enforcement is on.
+
+Deep links:
+- `docs/adrs/0024-contract-first-role-profiles-and-state-continuity-guard.md`
+- `docs/ubiquitous-language.md`
+
+### Chapter 5: Observability and Diagnosis
+
+Goal: read traces as an engineering feedback loop, not just logs.
+
+Exercise:
+1. run three prompts:
+   - top news from Google News, Yahoo, NYT,
+   - action-adventure movies in theaters,
+   - Jaffna Kool recipe.
+2. inspect log for:
+   - top-level outcome status by request,
+   - delegated calls and durations,
+   - guardrail retries and latest failure class,
+   - role-profile compliance fields.
+
+Code snippets (local trace exploration):
+```bash
+# 1) Quick tail
+tail -n 5 "$XDG_STATE_HOME/recurgent/recurgent.jsonl"
+
+# 2) Find top-level failures quickly
+rg '"depth":0' "$XDG_STATE_HOME/recurgent/recurgent.jsonl" | rg '"outcome_status":"error"'
+```
+
+```bash
+# 3) Structured summary by role + status
+ruby -rjson -e '
+path = ARGV[0]
+entries = File.readlines(path, chomp: true).map { |l| JSON.parse(l) }
+puts entries.group_by { |e| e["role"] }.transform_values { |xs|
+  xs.group_by { |e| e["outcome_status"] }.transform_values(&:count)
+}
+' "$XDG_STATE_HOME/recurgent/recurgent.jsonl"
+```
+
+Using Codex/Claude for log forensics:
+1. Give the assistant a concrete log path and intent.
+2. Ask for deterministic tables first, then interpretation.
+3. Ask for file/line-linked remediation suggestions.
+
+Prompt templates:
+```text
+Read this JSONL trace file: <absolute-path>.
+1) Produce a table of top-level calls (timestamp, role, method, status, error_type, duration_ms).
+2) Explain each error in plain engineering terms.
+3) Propose the smallest code or config change to fix each, with file references.
+```
+
+```text
+Compare these two trace files: <baseline-path> and <current-path>.
+Show what improved, what regressed, and what remained unchanged.
+Then propose one targeted experiment to validate each suspected cause.
+```
+
+Checkpoint:
+1. you can explain exactly why each request succeeded/failed,
+2. you can separate capability gaps from continuity/guardrail issues.
+
+Deep links:
+- `docs/observability.md`
+- `docs/reports/adr-0024-scope-hardcut-validation-report.md`
+
+### Chapter 6: Awareness vs Authority
+
+Goal: allow proposal generation without uncontrolled runtime mutation.
+
+Exercise:
+1. inspect `self_model`/awareness fields in logs,
+2. test proposal flows where apply requires maintainer authority.
+
+Code snippet:
+```ruby
+Agent.configure_runtime(
+  authority_enforcement_enabled: true,
+  authority_maintainers: %w[kulesh]
+)
+
+planner = Agent.for("planner")
+proposal = planner.propose(
+  proposal_type: "role_profile_update",
+  target: { role: "personal assistant that remembers conversation history", version: 2 },
+  proposed_diff_summary: "tighten conversation history continuity checks"
+)
+# apply_proposal(...) requires maintainer-authorized actor under enforcement
+```
+
+Checkpoint:
+1. observe/propose remains available,
+2. enact is gated by explicit authority settings and actor identity.
+
+Deep links:
+- `docs/adrs/0025-awareness-substrate-and-authority-boundary.md`
+- `docs/runtime-configuration.md`
+
+### Chapter 7: Production Readiness Pass
+
+Goal: convert example behavior into repeatable delivery quality.
+
+Checklist:
+1. local gates: `bundle exec rubocop`, `bundle exec rspec`,
+2. deterministic validation script for the three canonical prompts,
+3. trace review and issue creation for failures/regressions,
+4. PR with linked issue + verification evidence.
+
+Code snippet (minimal validation harness):
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd runtimes/ruby
+ROOT="$PWD/../../tmp/tutorial-assistant/prod-check"
+mkdir -p "$ROOT"
+
+mise exec -- env XDG_STATE_HOME="$ROOT/xdg" bundle exec rubocop
+mise exec -- env XDG_STATE_HOME="$ROOT/xdg" bundle exec rspec
+mise exec -- env XDG_STATE_HOME="$ROOT/xdg" ruby examples/assistant.rb < "$ROOT/assistant_input.txt"
+```
+
+Deep links:
+- `docs/open-source-release-checklist.md`
+- `docs/maintenance.md`
+- `docs/governance.md`
+
+## Suggested Exercise Loop per Chapter
+
+1. Run baseline chapter command.
+2. Apply the chapter change.
+3. Re-run with a fresh `XDG_STATE_HOME`.
+4. Capture:
+   - command output,
+   - JSONL trace summary,
+   - one-paragraph diagnosis (what improved / what regressed).
+
+## Common Pitfalls
+
+1. Mixing old/new state roots while comparing results.
+2. Enabling strict enforcement before enough shadow observations.
+3. Treating reliability metrics as semantic correctness guarantees.
+4. Adding role constraints that over-prescribe before coordination evidence.
+
+## Next Tutorial Candidates
+
+1. Debate moderator (multi-role coordination and structured outcomes).
+2. Tool promotion lifecycle (candidate -> probation -> durable -> degraded).
+3. Proposal-driven role-profile evolution with maintainer approval.


### PR DESCRIPTION
## Linked Issue (Required)

Closes #16

## Problem and User Value (Required)

The repo lacked a progressive, runnable tutorial that teaches Recurgent concepts with one evolving example. New contributors had to jump across ADRs and runtime code without a stepwise path. This PR adds an end-to-end learning path (personal assistant) plus a dedicated runtime configuration reference so engineers can move from quickstart to governed operation with concrete commands and trace inspection patterns.

## Solution Summary (Required)

- Added `docs/tutorials/personal-assistant-progressive.md` with chaptered progression from minimal loop -> runtime config -> delegation contracts -> provenance -> role profiles -> observability -> authority boundaries.
- Added copy/paste quickstart section with canonical assistant prompts and JSONL inspection commands.
- Added Recurgent UL term explanations in-context for tutorial readers.
- Added Codex/Claude log-forensics prompt templates and deterministic trace-summary commands.
- Added `docs/runtime-configuration.md` documenting `Agent.configure_runtime` keys, defaults, env vars, and recommended profiles.
- Updated `docs/index.md` and `AGENTS.md` retrieval index to include the new docs.

## Verification (Required)

```bash
cd runtimes/ruby
mise exec -- bundle exec rubocop
# 88 files inspected, no offenses detected

mise exec -- bundle exec rspec
# 259 examples, 0 failures
```

## Scope Declaration (Required)

This PR only addresses documentation onboarding/tutorial coverage and runtime-config reference material tied to issue #16. No runtime behavior changes are included.

## Contributor Acknowledgements (Required)

- [x] I linked an approved issue for this PR.
- [x] I ran relevant tests/lint and reported results above.
- [x] I reviewed every changed line and can explain it.
- [x] I read and agree to follow `CONTRIBUTING.md`.
- [x] I read and agree to follow `CODE_OF_CONDUCT.md`.
