### PR TITLE
Harden OpenAI/runtime execution and block self-materialization loops

### DIFF
--- a/runtimes/ruby/lib/recurgent/environment_manager.rb
+++ b/runtimes/ruby/lib/recurgent/environment_manager.rb
@@ -120,7 +120,13 @@ class Agent
     def _run_bundle_install(env_dir)
       _run_bundle_command(
         env_dir,
-        ["install", "--path", "vendor/bundle", "--jobs", "4", "--retry", "2"],
+        ["config", "set", "--local", "path", "vendor/bundle"],
+        Agent::DependencyInstallError,
+        "bundle config set path"
+      )
+      _run_bundle_command(
+        env_dir,
+        ["install", "--jobs", "4", "--retry", "2"],
         Agent::DependencyInstallError,
         "bundle install"
       )

--- a/runtimes/ruby/lib/recurgent/role_profile_guard.rb
+++ b/runtimes/ruby/lib/recurgent/role_profile_guard.rb
@@ -200,7 +200,7 @@ class Agent
       metadata = _toolstore_load_registry_tools[@role.to_s]
       shape_profiles = _role_profile_method_return_shapes(metadata || {})
       shape_profiles.merge!(_role_profile_cached_observations(kind: :return_shape_family))
-      current_shape = _role_profile_value_shape(outcome.value)
+      current_shape = outcome&.ok? ? _role_profile_value_shape(outcome.value) : nil
       unless current_shape.nil?
         shape_profiles[method_name.to_s] = current_shape
         _role_profile_record_observation(kind: :return_shape_family, method_name: method_name, value: current_shape)

--- a/runtimes/ruby/spec/environment_manager_spec.rb
+++ b/runtimes/ruby/spec/environment_manager_spec.rb
@@ -68,8 +68,9 @@ RSpec.describe Agent::EnvironmentManager do
 
     expect(first[:environment_cache_hit]).to eq(false)
     expect(second[:environment_cache_hit]).to eq(true)
-    expect(commands.size).to eq(2)
+    expect(commands.size).to eq(3)
     expect(commands.map(&:join)).to include(a_string_including("bundlelock"))
+    expect(commands.map(&:join)).to include(a_string_including("bundleconfigset--localpathvendor/bundle"))
     expect(commands.map(&:join)).to include(a_string_including("bundleinstall"))
   end
 
@@ -98,7 +99,7 @@ RSpec.describe Agent::EnvironmentManager do
 
     expect(first[:environment_cache_hit]).to eq(false)
     expect(second[:environment_cache_hit]).to eq(false)
-    expect(commands.size).to eq(4)
+    expect(commands.size).to eq(6)
   end
 
   it "raises dependency_resolution_failed on bundle lock failure" do


### PR DESCRIPTION
## Linked Issue (Required)

Closes #24

## Problem and User Value (Required)

OpenAI model execution regressed in three places: strict schema rejection at provider boundary, dependency install failure on modern Bundler, and recursive self-materialization loops in tool calls. These failures break core example flows (`calculator`, assistant news/movie/recipe) and reduce runtime reliability.

## Solution Summary (Required)

- OpenAI provider: normalize strict JSON schema so object properties satisfy strict `required` rules while preserving optional semantics via nullable types.
- Environment manager: replace deprecated `bundle install --path ...` usage with `bundle config set --local path vendor/bundle` + `bundle install`.
- Runtime recursion guard: block self-materialization in `tool()` and `delegate()` for the current role and add explicit identity guidance in system prompt.
- Role profile continuity: treat return-shape coordination observations only for successful outcomes.
- Added regression specs for provider schema normalization, environment install command flow, prompt identity guidance, and self-materialization guard behavior.

## Verification (Required)

```bash
cd runtimes/ruby
mise x -- bundle exec rubocop lib/recurgent/providers.rb spec/agent/providers_spec.rb
mise x -- bundle exec rspec spec/agent/providers_spec.rb
mise x -- bundle exec rubocop lib/recurgent/environment_manager.rb spec/environment_manager_spec.rb
mise x -- bundle exec rspec spec/environment_manager_spec.rb
mise x -- bundle exec rubocop lib/recurgent.rb lib/recurgent/prompting.rb spec/agent/prompt_construction_spec.rb spec/recurgent_spec.rb
mise x -- bundle exec rspec spec/agent/prompt_construction_spec.rb spec/recurgent_spec.rb:580 spec/recurgent_spec.rb:676
mise x -- ruby examples/calculator.rb
# plus OpenAI calculator + assistant scenario runs executed from inline Ruby harnesses
```

Outcomes:
- All listed rubocop and rspec runs passed.
- OpenAI calculator no longer fails with strict schema provider error.
- Assistant OpenAI run no longer fails with `dependency_install_failed`.
- Self-recursive `tool("news_aggregator")` delegation loop is blocked by runtime guard.

## Scope Declaration (Required)

This PR addresses issue #24 only: OpenAI/runtime execution hardening and associated regression coverage. No unrelated product/ADR changes are included.

## Contributor Acknowledgements (Required)

- [x] I linked an approved issue for this PR.
- [x] I ran relevant tests/lint and reported results above.
- [x] I reviewed every changed line and can explain it.
- [x] I read and agree to follow `CONTRIBUTING.md`.
- [x] I read and agree to follow `CODE_OF_CONDUCT.md`.
