### PR TITLE
Refresh README and add v1 observability log schemas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,7 +206,7 @@ runtimes/
 
 ## Retrieval Index
 
-Last Updated (UTC): 2026-02-21T07:05:00Z
+Last Updated (UTC): 2026-02-21T21:10:00Z
 
 - `README.md` - project introduction, quickstart, architecture snapshot, FAQ
 - `LICENSE` - MIT open source license
@@ -301,6 +301,8 @@ Last Updated (UTC): 2026-02-21T07:05:00Z
 - `specs/contract/v1/tolerant-delegation-profile.md` - tolerant delegation profile contract
 - `specs/contract/v1/tolerant-delegation-scenarios.yaml` - tolerant delegation scenario suite (v1)
 - `specs/contract/v1/conformance.md` - runtime harness conformance guidance
+- `specs/contract/v1/recurgent-log-entry.schema.json` - machine-readable schema for one JSONL observability log entry
+- `specs/contract/v1/recurgent-log-stream.schema.json` - schema for JSON-array form of the JSONL log stream
 - `runtimes/ruby/lib/recurgent.rb` - core runtime dispatch, execution, retry, and outcome mapping
 - `runtimes/ruby/lib/recurgent/prompting.rb` - system/user prompt construction and tool schema
 - `runtimes/ruby/lib/recurgent/observability.rb` - JSONL log composition and debug capture

--- a/docs/index.md
+++ b/docs/index.md
@@ -105,5 +105,7 @@ This index is organized for fast retrieval:
 - [`specs/contract/README.md`](../specs/contract/README.md) - runtime-agnostic contract package
 - [`specs/contract/v1/agent-contract.md`](../specs/contract/v1/agent-contract.md) - normative behavior contract
 - [`specs/contract/v1/scenarios.yaml`](../specs/contract/v1/scenarios.yaml) - shared conformance scenarios
+- [`specs/contract/v1/recurgent-log-entry.schema.json`](../specs/contract/v1/recurgent-log-entry.schema.json) - machine-readable schema for one observability log entry
+- [`specs/contract/v1/recurgent-log-stream.schema.json`](../specs/contract/v1/recurgent-log-stream.schema.json) - schema for JSON-array form of `recurgent.jsonl`
 - [`runtimes/ruby/README.md`](../runtimes/ruby/README.md) - Ruby runtime quick reference
 - [`runtimes/lua/README.md`](../runtimes/lua/README.md) - Lua runtime placeholder

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -2,6 +2,34 @@
 
 Recurgent emits JSONL call logs designed for runtime introspection across Ruby and Lua.
 
+## Machine-Readable Schemas
+
+Log schemas are versioned under the contract package:
+
+- Entry schema: [`specs/contract/v1/recurgent-log-entry.schema.json`](../specs/contract/v1/recurgent-log-entry.schema.json)
+- Stream schema: [`specs/contract/v1/recurgent-log-stream.schema.json`](../specs/contract/v1/recurgent-log-stream.schema.json)
+
+Validation example with `ajv-cli`:
+
+```bash
+LOG="${XDG_STATE_HOME:-$HOME/.local/state}/recurgent/recurgent.jsonl"
+jq -s . "$LOG" > /tmp/recurgent-log-stream.json
+
+npx -y ajv-cli validate \
+  --spec=draft2020 \
+  --strict=false \
+  -s specs/contract/v1/recurgent-log-stream.schema.json \
+  -r specs/contract/v1/recurgent-log-entry.schema.json \
+  -d /tmp/recurgent-log-stream.json
+```
+
+Quick "modern contract fields present" check:
+
+```bash
+LOG="${XDG_STATE_HOME:-$HOME/.local/state}/recurgent/recurgent.jsonl"
+jq -c 'select((has("runtime") and has("outcome_status") and has("contract_source")) | not)' "$LOG" | head
+```
+
 ## Live Watcher
 
 Use the shared watcher at repository root:

--- a/docs/tutorials/personal-assistant-progressive.md
+++ b/docs/tutorials/personal-assistant-progressive.md
@@ -399,6 +399,7 @@ Read traces as an engineering feedback loop, not just output records.
 
 - [`docs/observability.md`](../observability.md) (field catalog and operator queries)
 - [`docs/architecture.md`](../architecture.md) (where observability fits in lifecycle)
+- [`specs/contract/v1/recurgent-log-entry.schema.json`](../../specs/contract/v1/recurgent-log-entry.schema.json) (machine-readable per-entry schema)
 
 ### Useful commands
 

--- a/runtimes/ruby/examples/fib.rb
+++ b/runtimes/ruby/examples/fib.rb
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../lib/recurgent"
+
+puts "=== Calculate Fibonacci ==="
+puts "No Math module. No formulas. No operator overloading."
+puts "Just a name and method calls. The LLM figures out the rest."
+puts
+
+fcalc = Agent.for("fibonacci_calculator")
+puts fcalc.fibonacci(1000)

--- a/specs/contract/README.md
+++ b/specs/contract/README.md
@@ -19,6 +19,8 @@ specs/contract/
     scenarios.yaml       # runtime-agnostic test scenarios
     tolerant-delegation-profile.md    # tolerant delegation profile
     tolerant-delegation-scenarios.yaml  # tolerant profile scenarios
+    recurgent-log-entry.schema.json    # machine-readable schema for one JSONL log entry
+    recurgent-log-stream.schema.json   # schema for jq-slurped JSONL stream arrays
     conformance.md       # harness guidance for runtime implementations
 ```
 

--- a/specs/contract/v1/recurgent-log-entry.schema.json
+++ b/specs/contract/v1/recurgent-log-entry.schema.json
@@ -1,0 +1,480 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "recurgent-log-entry.schema.json",
+  "title": "Recurgent Log Entry (v1, tolerant)",
+  "description": "Machine-readable schema for one JSONL observability entry. Tolerant by default: known fields are typed, unknown future fields are allowed.",
+  "type": "object",
+  "required": [
+    "timestamp",
+    "role",
+    "model",
+    "method",
+    "args",
+    "kwargs",
+    "code",
+    "duration_ms",
+    "generation_attempt"
+  ],
+  "properties": {
+    "timestamp": {
+      "type": "string"
+    },
+    "runtime": {
+      "type": "string",
+      "minLength": 1
+    },
+    "role": {
+      "type": "string",
+      "minLength": 1
+    },
+    "model": {
+      "type": "string",
+      "minLength": 1
+    },
+    "method": {
+      "type": "string",
+      "minLength": 1
+    },
+    "args": {
+      "type": "array"
+    },
+    "kwargs": {
+      "type": "object"
+    },
+    "code": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "duration_ms": {
+      "type": "number",
+      "minimum": 0
+    },
+    "generation_attempt": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "contract_source": {
+      "type": "string",
+      "enum": [
+        "none",
+        "hash",
+        "fields",
+        "merged"
+      ]
+    },
+    "trace_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "call_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "parent_call_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "depth": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0
+    },
+    "execution_receiver": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "sandbox",
+        "worker",
+        null
+      ]
+    },
+    "outcome_status": {
+      "type": "string",
+      "enum": [
+        "ok",
+        "error"
+      ]
+    },
+    "outcome_retriable": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "outcome_tool_role": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "outcome_method_name": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "outcome_value_class": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "outcome_error_type": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "outcome_error_message": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "outcome_error_metadata": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": true
+    },
+    "attempt_id": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0
+    },
+    "attempt_stage": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "validation_failure_type": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "rollback_applied": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "retry_feedback_injected": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "guardrail_recovery_attempts": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0
+    },
+    "execution_repair_attempts": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0
+    },
+    "outcome_repair_attempts": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0
+    },
+    "outcome_repair_triggered": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "guardrail_retry_exhausted": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "outcome_repair_retry_exhausted": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "solver_shape": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": true
+    },
+    "solver_shape_complete": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "solver_shape_stance": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "solver_shape_promotion_intent": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "promotion_policy_version": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "lifecycle_state": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "candidate",
+        "probation",
+        "durable",
+        "degraded",
+        null
+      ]
+    },
+    "lifecycle_decision": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "promote",
+        "continue_probation",
+        "degrade",
+        "hold",
+        null
+      ]
+    },
+    "promotion_decision_rationale": {
+      "type": [
+        "string",
+        "object",
+        "array",
+        "null"
+      ]
+    },
+    "promotion_shadow_mode": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "promotion_enforced": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "namespace_key_collision_count": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0
+    },
+    "namespace_multi_lifetime_key_count": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0
+    },
+    "namespace_continuity_violation_count": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0
+    },
+    "attempt_failures": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "attempt_id": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "stage": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "error_class": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "error_message": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "timestamp": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "call_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "history_record_appended": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "conversation_history_size": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0
+    },
+    "history_access_detected": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "history_query_patterns": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "content_store_write_applied": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "content_store_write_ref": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "content_store_write_kind": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "content_store_write_bytes": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0
+    },
+    "content_store_write_digest": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "content_store_write_skipped_reason": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "content_store_eviction_count": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0
+    },
+    "content_store_read_hit_count": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0
+    },
+    "content_store_read_miss_count": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0
+    },
+    "content_store_read_refs": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "content_store_entry_count": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0
+    },
+    "content_store_total_bytes": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0
+    }
+  },
+  "additionalProperties": true
+}

--- a/specs/contract/v1/recurgent-log-stream.schema.json
+++ b/specs/contract/v1/recurgent-log-stream.schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "recurgent-log-stream.schema.json",
+  "title": "Recurgent JSONL Log Stream (v1)",
+  "description": "Schema for an in-memory JSON array of log entries (for example, from `jq -s . recurgent.jsonl`).",
+  "type": "array",
+  "items": {
+    "$ref": "recurgent-log-entry.schema.json"
+  }
+}


### PR DESCRIPTION
## Linked Issue (Required)

Closes #31

## Problem and User Value (Required)

The working tree had accumulated README/docs/spec changes plus a new fibonacci example, and observability still lacked a machine-readable log schema contract. This made onboarding and trace debugging less predictable.

## Solution Summary (Required)

- Refreshed `README.md` structure/content per latest decisions:
  - removed FAQ and "Who This Is For"
  - simplified Quickstart (Ruby/Bundler-first)
  - expanded Known Limitations with concrete examples + deep links
  - reordered sections as requested
- Added executable Ruby example: `runtimes/ruby/examples/fib.rb`.
- Added versioned observability schemas:
  - `specs/contract/v1/recurgent-log-entry.schema.json`
  - `specs/contract/v1/recurgent-log-stream.schema.json`
- Updated observability/tutorial/index docs with schema references and validation commands.
- Updated retrieval index entries in `AGENTS.md`.

## Verification (Required)

```bash
cd runtimes/ruby
mise exec -- bundle exec rubocop
# 91 files inspected, no offenses

mise exec -- bundle exec rspec
# 273 examples, 0 failures

cd ../..
LOG="${XDG_STATE_HOME:-$HOME/.local/state}/recurgent/recurgent.jsonl"
jq -s . "$LOG" > /tmp/recurgent-log-stream.json
npx -y ajv-cli validate \
  --spec=draft2020 \
  --strict=false \
  -s specs/contract/v1/recurgent-log-stream.schema.json \
  -r specs/contract/v1/recurgent-log-entry.schema.json \
  -d /tmp/recurgent-log-stream.json
# /tmp/recurgent-log-stream.json valid
```

## Scope Declaration (Required)

This PR only addresses the pending working-tree cleanup and the requested observability schema documentation/contract additions. No unrelated runtime behavior changes were introduced.

## Contributor Acknowledgements (Required)

- [x] I linked an approved issue for this PR.
- [x] I ran relevant tests/lint and reported results above.
- [x] I reviewed every changed line and can explain it.
- [x] I read and agree to follow `CONTRIBUTING.md`.
- [x] I read and agree to follow `CODE_OF_CONDUCT.md`.
