### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 ### Three Core Ideas
 
-1. **Interface:** Model backed dynamic dispatch
+1. **Interface:** Model backed dynamic dispatch. 
    Behavior is infered and created at runtime by a backing model.
-2. **Environment:** Agents compose themselves
+2. **Environment:** Agents compose themselves. 
    Agents compose themselves by building other agents to delegate work. Humans just sketch intent and boundaries.
-3. **Evolution:** Outcome is shaped, not prescribed
+3. **Evolution:** Outcome is shaped, not prescribed. 
    Contracts and traces provide directional pressure so emergence stays reliable and intelligible.
 
 Recurgent doesn't produce code. It produces a tool-building organism that produces code. You give it a role and an environment. It discovers what tools it needs, builds them, and gets better over time.


### PR DESCRIPTION
## Linked Issue (Required)
Closes #55

## Problem and User Value (Required)
README list headings in the Three Core Ideas section had inconsistent punctuation.

## Solution Summary (Required)
Adds terminal periods to the three numbered heading lines for consistent style.

## Verification (Required)
- CI checks on PR #52 passed before merge review.
- Change is documentation-only (`README.md`).

## Scope Declaration (Required)
This PR only updates README punctuation and includes no runtime or workflow changes.

## Contributor Acknowledgements (Required)
- [x] I linked an approved issue for this PR.
- [x] I ran relevant tests/lint and reported results above.
- [x] I reviewed every changed line and can explain it.
- [x] I read and agree to follow `CONTRIBUTING.md`.
- [x] I read and agree to follow `CODE_OF_CONDUCT.md`.
