### PR TITLE
Fix bundler-audit: bump mcp 0.8.0→0.9.2 and json 2.19.0→2.19.2

### DIFF
--- a/runtimes/ruby/Gemfile.lock
+++ b/runtimes/ruby/Gemfile.lock
@@ -20,7 +20,7 @@ GEM
     cgi (0.5.1)
     connection_pool (3.0.2)
     diff-lcs (1.6.2)
-    json (2.19.0)
+    json (2.19.2)
     json-schema (6.2.0)
       addressable (~> 2.8)
       bigdecimal (>= 3.1, < 5)
@@ -93,7 +93,7 @@ CHECKSUMS
   cgi (0.5.1) sha256=e93fcafc69b8a934fe1e6146121fa35430efa8b4a4047c4893764067036f18e9
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
-  json (2.19.0) sha256=bc5202f083618b3af7aba3184146ec9d820f8f6de261838b577173475e499d9a
+  json (2.19.2) sha256=e7e1bd318b2c37c4ceee2444841c86539bc462e81f40d134cf97826cb14e83cf
   json-schema (6.2.0) sha256=e8bff46ed845a22c1ab2bd0d7eccf831c01fe23bb3920caa4c74db4306813666
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87

--- a/runtimes/ruby/Gemfile.lock
+++ b/runtimes/ruby/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
       connection_pool
     ast (2.4.3)
     base64 (0.3.0)
-    bigdecimal (4.0.1)
+    bigdecimal (4.1.0)
     cgi (0.5.1)
     connection_pool (3.0.2)
     diff-lcs (1.6.2)
@@ -26,7 +26,7 @@ GEM
       bigdecimal (>= 3.1, < 5)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
-    mcp (0.8.0)
+    mcp (0.9.2)
       json-schema (>= 4.1)
     parallel (1.27.0)
     parser (3.3.10.2)
@@ -89,7 +89,7 @@ CHECKSUMS
   anthropic (1.23.0) sha256=6290309d1f6488d132b6fd5a79d8d5414ef09f281d6668f930c2cd88658b9d82
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
-  bigdecimal (4.0.1) sha256=8b07d3d065a9f921c80ceaea7c9d4ae596697295b584c296fe599dd0ad01c4a7
+  bigdecimal (4.1.0) sha256=6dc07767aa3dc456ccd48e7ae70a07b474e9afd7c5bc576f80bd6da5c8dd6cae
   cgi (0.5.1) sha256=e93fcafc69b8a934fe1e6146121fa35430efa8b4a4047c4893764067036f18e9
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
@@ -97,7 +97,7 @@ CHECKSUMS
   json-schema (6.2.0) sha256=e8bff46ed845a22c1ab2bd0d7eccf831c01fe23bb3920caa4c74db4306813666
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
-  mcp (0.8.0) sha256=ae8bd146bb8e168852866fd26f805f52744f6326afb3211e073f78a95e0c34fb
+  mcp (0.9.2) sha256=d413926f4f9dc1274f462196c2a9fbf9cb261ecd3c66a60c82eb71ee62bd2932
   parallel (1.27.0) sha256=4ac151e1806b755fb4e2dc2332cbf0e54f2e24ba821ff2d3dcf86bf6dc4ae130
   parser (3.3.10.2) sha256=6f60c84aa4bdcedb6d1a2434b738fe8a8136807b6adc8f7f53b97da9bc4e9357
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85


### PR DESCRIPTION
## Linked Issue (Required)

Closes #67

## Problem and User Value (Required)

`bundler-audit` CI check is failing on all PRs due to two known vulnerabilities in indirect dependencies (via rubocop):

1. **mcp 0.8.0** — CVE-2026-33946: Insufficient session binding allows SSE stream hijacking via session ID replay. Fixed in 0.9.2.
2. **json 2.19.0** — CVE-2026-33210: Format string injection when using `allow_duplicate_key: false`. Can cause DoS or information disclosure. Fixed in 2.19.2.

Both are transitive dependencies pulled in by `rubocop ~> 1.85`, which requires `mcp ~> 0.6` and `json ~> 2.3`. The patched versions are compatible with these constraints.

## Solution Summary (Required)

Update `Gemfile.lock` to resolve both advisories:
- `mcp` 0.8.0 → 0.9.2
- `json` 2.19.0 → 2.19.2
- `bigdecimal` 4.0.1 → 4.1.0 (transitive, pulled in by mcp update)

Supersedes Dependabot PR #61 which only addressed `mcp`.

## Verification (Required)

CI checks on this PR:
- Ruby test and lint: passed
- Class-1 Readiness (calculator-core-v1): passed
- Class-1 Readiness (calculator-edge-v1): passed
- CodeQL: passed
- dependency-review: passed
- gitleaks: passed
- bundler-audit: pending re-run with json fix

## Scope Declaration (Required)

This PR only updates `Gemfile.lock` to resolve the two CVEs described in #67. No other changes.

## Contributor Acknowledgements (Required)

- [x] I linked an approved issue for this PR.
- [x] I ran relevant tests/lint and reported results above.
- [x] I reviewed every changed line and can explain it.
- [x] I read and agree to follow `CONTRIBUTING.md`.
- [x] I read and agree to follow `CODE_OF_CONDUCT.md`.